### PR TITLE
test: add support for devkit

### DIFF
--- a/tests/e2e/setup/010-build-devkit.ts
+++ b/tests/e2e/setup/010-build-devkit.ts
@@ -1,0 +1,19 @@
+import {join} from 'path';
+import {getGlobalVariable} from '../utils/env';
+import { exec, npm } from '../utils/process';
+import {updateJsonFile} from '../utils/project';
+
+const packages = require('../../../lib/packages').packages;
+
+export default function() {
+  const argv = getGlobalVariable('argv');
+
+  if (argv.nobuild) {
+    return;
+  }
+  if (!argv.devkit) {
+    return;
+  }
+
+  return exec(`${argv.devkit}/bin/devkit-admin`, 'build', '--local');
+}

--- a/tests/e2e/setup/015-build.ts
+++ b/tests/e2e/setup/015-build.ts
@@ -12,7 +12,7 @@ export default function() {
     return;
   }
 
-  return npm('run', 'build', '--', '--local')
+  return npm('run', 'build', '--', '--local', argv.devkit ? '--devkit=' + argv.devkit : undefined)
     .then(() => {
       if (!argv.nightly && !argv['ng-sha']) {
         return;

--- a/tests/e2e/setup/500-create-project.ts
+++ b/tests/e2e/setup/500-create-project.ts
@@ -7,8 +7,9 @@ import {
   useNg2,
   useSha,
   useCIChrome,
-  useCIDefaults
+  useCIDefaults,
   useBuiltPackages,
+  useDevKit,
 } from '../utils/project';
 import {gitClean, gitCommit} from '../utils/git';
 import {getGlobalVariable} from '../utils/env';
@@ -40,6 +41,7 @@ export default function() {
   return Promise.resolve()
     .then(() => createProject)
     .then(() => useBuiltPackages())
+    .then(() => argv.devkit && useDevKit(argv.devkit))
     .then(() => useCIChrome())
     .then(() => useCIDefaults())
     .then(() => argv['ng2'] ? useNg2() : Promise.resolve())

--- a/tests/e2e/utils/project.ts
+++ b/tests/e2e/utils/project.ts
@@ -47,6 +47,32 @@ export function createProject(name: string, ...args: string[]) {
     .then(() => silentNpm('install'));
 }
 
+
+export function useDevKit(devkitRoot: string) {
+  return Promise.resolve()
+    .then(() => {
+      // Load the packages info for devkit.
+      const devkitPackages = require(devkitRoot + '/lib/packages').packages;
+
+      return updateJsonFile('package.json', json => {
+          if (!json['dependencies']) {
+            json['dependencies'] = {};
+          }
+          if (!json['devDependencies']) {
+            json['devDependencies'] = {};
+          }
+
+          for (const packageName of Object.keys(devkitPackages)) {
+            if (json['dependencies'].hasOwnProperty(packageName)) {
+              json['dependencies'][packageName] = devkitPackages[packageName].tar;
+            } else if (json['devDependencies'].hasOwnProperty(packageName)) {
+              json['devDependencies'][packageName] = devkitPackages[packageName].tar;
+            }
+          }
+        });
+    });
+}
+
 export function useBuiltPackages() {
   return Promise.resolve()
     .then(() => updateJsonFile('package.json', json => {

--- a/tests/e2e_runner.ts
+++ b/tests/e2e_runner.ts
@@ -40,6 +40,7 @@ Error.stackTraceLimit = Infinity;
  *   --nb-shards      Total number of shards that this is part of. Default is 2 if --shard is
  *                    passed in.
  *   --shard          Index of this processes' shard.
+ *   --devkit=path    Path to the devkit to use. The devkit will be built prior to running.
  * If unnamed flags are passed in, the list of tests will be filtered to include only those passed.
  */
 const argv = minimist(process.argv.slice(2), {
@@ -53,7 +54,7 @@ const argv = minimist(process.argv.slice(2), {
     'noproject',
     'verbose',
   ],
-  'string': ['glob', 'ignore', 'reuse', 'ng-sha', ],
+  'string': ['devkit', 'glob', 'ignore', 'reuse', 'ng-sha', ],
   'number': ['nb-shards', 'shard']
 });
 

--- a/tools/publish/src/build.ts
+++ b/tools/publish/src/build.ts
@@ -57,7 +57,8 @@ function getDeps(pkg: any): any {
 }
 
 
-export default function build(packagesToBuild: string[], opts: { local: boolean },
+export default function build(packagesToBuild: string[],
+                              opts: { local: boolean, devkit: string },
                               logger: Logger): Promise<void> {
   const { packages, tools } = require('../../../lib/packages');
 
@@ -253,6 +254,20 @@ export default function build(packagesToBuild: string[], opts: { local: boolean 
             json['dependencies'][packageName] = packages[packageName].tar;
           } else if (json['devDependencies'].hasOwnProperty(packageName)) {
             json['devDependencies'][packageName] = packages[packageName].tar;
+          }
+        }
+
+        if (opts.devkit) {
+          // Load the packages info for devkit.
+          const devkitPackages = require(opts.devkit + '/lib/packages').packages;
+
+          for (const packageName of Object.keys(devkitPackages)) {
+            console.log(pkgName, packageName);
+            if (json['dependencies'].hasOwnProperty(packageName)) {
+              json['dependencies'][packageName] = devkitPackages[packageName].tar;
+            } else if (json['devDependencies'].hasOwnProperty(packageName)) {
+              json['devDependencies'][packageName] = devkitPackages[packageName].tar;
+            }
           }
         }
 


### PR DESCRIPTION
Using --devkit=/absolute/path/to/devkit/repo the e2e tests will now
run with the devkit passed in. It will build the devkit first, then
change the package.json to use the proper devkit tgz.