### PR TITLE
Update upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6550,40 +6550,6 @@
         "postcss-value-parser": "3.3.0"
       }
     },
-    "postcss-custom-properties": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.1.0.tgz",
-      "integrity": "sha1-nK8RUaxBsenmTTov+ezplsoYl30=",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "postcss": "6.0.11"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "postcss": {
-          "version": "6.0.11",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
-          "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
-          "requires": {
-            "chalk": "2.2.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
-      }
-    },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "nopt": "^4.0.1",
     "opn": "~5.1.0",
     "portfinder": "~1.0.12",
-    "postcss-custom-properties": "^6.1.0",
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.10",
     "postcss-url": "^7.1.2",

--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -11,7 +11,6 @@ import { CleanCssWebpackPlugin } from '../../plugins/cleancss-webpack-plugin';
 const postcssUrl = require('postcss-url');
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const customProperties = require('postcss-custom-properties');
 const postcssImports = require('postcss-import');
 
 /**
@@ -115,14 +114,12 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         }
       ]),
       autoprefixer(),
-      customProperties({ preserve: true })
     ];
   };
   (postcssPluginCreator as any)[postcssArgs] = {
     variableImports: {
       'autoprefixer': 'autoprefixer',
       'postcss-url': 'postcssUrl',
-      'postcss-custom-properties': 'customProperties',
       'postcss-import': 'postcssImports',
     },
     variables: { minimizeCss, baseHref, deployUrl, projectRoot }

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -60,7 +60,6 @@
     "nopt": "^4.0.1",
     "opn": "~5.1.0",
     "portfinder": "~1.0.12",
-    "postcss-custom-properties": "^6.1.0",
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.10",
     "postcss-url": "^7.1.2",

--- a/packages/@angular/cli/plugins/scripts-webpack-plugin.ts
+++ b/packages/@angular/cli/plugins/scripts-webpack-plugin.ts
@@ -116,7 +116,7 @@ export class ScriptsWebpackPlugin {
             const concatSource = new ConcatSource();
             sources.forEach(source => {
               concatSource.add(source);
-              concatSource.add('\n');
+              concatSource.add('\n;');
             });
 
             const combinedSource = new CachedSource(concatSource);

--- a/packages/@angular/cli/utilities/stats.ts
+++ b/packages/@angular/cli/utilities/stats.ts
@@ -26,11 +26,9 @@ export function statsToString(json: any, statsConfig: any) {
   const g = (x: string) => colors ? bold(green(x)) : x;
   const y = (x: string) => colors ? bold(yellow(x)) : x;
 
-  return rs(stripIndents`
-    Date: ${w(new Date().toISOString())}
-    Hash: ${w(json.hash)}
-    Time: ${w('' + json.time)}ms
-    ${json.chunks.map((chunk: any) => {
+  const changedChunksStats = json.chunks
+    .filter((chunk: any) => chunk.rendered)
+    .map((chunk: any) => {
       const asset = json.assets.filter((x: any) => x.name == chunk.files[0])[0];
       const size = asset ? ` ${_formatSize(asset.size)}` : '';
       const files = chunk.files.join(', ');
@@ -41,8 +39,24 @@ export function statsToString(json: any, statsConfig: any) {
         .join('');
 
       return `chunk {${y(chunk.id)}} ${g(files)}${names}${size} ${initial}${flags}`;
-    }).join('\n')}
-    `);
+    });
+
+  const unchangedChunkNumber = json.chunks.length - changedChunksStats.length;
+
+  if (unchangedChunkNumber > 0) {
+    return rs(stripIndents`
+      Date: ${w(new Date().toISOString())} • Hash: ${w(json.hash)} • Time: ${w('' + json.time)}ms
+      ${unchangedChunkNumber} unchanged chunks
+      ${changedChunksStats.join('\n')}
+      `);
+  } else {
+    return rs(stripIndents`
+      Date: ${w(new Date().toISOString())}
+      Hash: ${w(json.hash)}
+      Time: ${w('' + json.time)}ms
+      ${changedChunksStats.join('\n')}
+      `);
+  }
 }
 
 export function statsWarningsToString(json: any, statsConfig: any) {

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -19,6 +19,7 @@ import {
 import { resolveEntryModuleFromMain } from './entry_resolver';
 import {
   replaceBootstrap,
+  replaceServerBootstrap,
   exportNgFactory,
   exportLazyModuleMap,
   removeDecorators,
@@ -697,7 +698,9 @@ export class AngularCompilerPlugin implements Tapable {
     } else if (this._platform === PLATFORM.Server) {
       this._transformers.push(exportLazyModuleMap(isMainPath, getLazyRoutes));
       if (!this._JitMode) {
-        this._transformers.push(exportNgFactory(isMainPath, getEntryModule));
+        this._transformers.push(
+          exportNgFactory(isMainPath, getEntryModule),
+          replaceServerBootstrap(isMainPath, getEntryModule, getTypeChecker));
       }
     }
   }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -27,7 +27,7 @@ import {
   replaceResources,
 } from './transformers';
 import { time, timeEnd } from './benchmark';
-import { InitMessage, UpdateMessage } from './type_checker';
+import { InitMessage, UpdateMessage, AUTO_START_ARG } from './type_checker';
 import { gatherDiagnostics, hasErrors } from './gather_diagnostics';
 import {
   CompilerCliIsSupported,
@@ -466,7 +466,7 @@ export class AngularCompilerPlugin implements Tapable {
     const g: any = global;
     const typeCheckerFile: string = g['angularCliIsLocal']
       ? './type_checker_bootstrap.js'
-      : './type_checker.js';
+      : './type_checker_worker.js';
 
     const debugArgRegex = /--inspect(?:-brk|-port)?|--debug(?:-brk|-port)/;
 
@@ -475,10 +475,15 @@ export class AngularCompilerPlugin implements Tapable {
       // Workaround for https://github.com/nodejs/node/issues/9435
       return !debugArgRegex.test(arg);
     });
-
+    // Signal the process to start listening for messages
+    // Solves https://github.com/angular/angular-cli/issues/9071
+    const forkArgs = [AUTO_START_ARG];
     const forkOptions: ForkOptions = { execArgv };
 
-    this._typeCheckerProcess = fork(path.resolve(__dirname, typeCheckerFile), [], forkOptions);
+    this._typeCheckerProcess = fork(
+      path.resolve(__dirname, typeCheckerFile),
+      forkArgs,
+      forkOptions);
     this._typeCheckerProcess.send(new InitMessage(this._compilerOptions, this._basePath,
       this._JitMode, this._rootNames));
 

--- a/packages/@ngtools/webpack/src/transformers/index.ts
+++ b/packages/@ngtools/webpack/src/transformers/index.ts
@@ -4,6 +4,7 @@ export * from './make_transform';
 export * from './insert_import';
 export * from './elide_imports';
 export * from './replace_bootstrap';
+export * from './replace_server_bootstrap';
 export * from './export_ngfactory';
 export * from './export_lazy_module_map';
 export * from './register_locale_data';

--- a/packages/@ngtools/webpack/src/transformers/replace_server_bootstrap.spec.ts
+++ b/packages/@ngtools/webpack/src/transformers/replace_server_bootstrap.spec.ts
@@ -1,0 +1,215 @@
+import { oneLine, stripIndent } from 'common-tags';
+import { createTypescriptContext, transformTypescript } from './ast_helpers';
+import { replaceServerBootstrap } from './replace_server_bootstrap';
+
+describe('@ngtools/webpack transformers', () => {
+  describe('replace_server_bootstrap', () => {
+    it('should replace bootstrap', () => {
+      const input = stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { platformDynamicServer } from '@angular/platform-server';
+
+        import { AppModule } from './app/app.module';
+        import { environment } from './environments/environment';
+
+        if (environment.production) {
+          enableProdMode();
+        }
+
+        platformDynamicServer().bootstrapModule(AppModule);
+      `;
+
+      // tslint:disable:max-line-length
+      const output = stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { environment } from './environments/environment';
+
+        import * as __NgCli_bootstrap_1 from "./app/app.module.ngfactory";
+        import * as __NgCli_bootstrap_2 from "@angular/platform-server";
+
+        if (environment.production) {
+          enableProdMode();
+        }
+        __NgCli_bootstrap_2.platformServer().bootstrapModuleFactory(__NgCli_bootstrap_1.AppModuleNgFactory);
+      `;
+      // tslint:enable:max-line-length
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const transformer = replaceServerBootstrap(
+        () => true,
+        () => ({ path: '/project/src/app/app.module', className: 'AppModule' }),
+        () => program.getTypeChecker(),
+      );
+      const result = transformTypescript(undefined, [transformer], program, compilerHost);
+
+      expect(oneLine`${result}`).toEqual(oneLine`${output}`);
+    });
+
+    it('should replace renderModule', () => {
+      const input = stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { renderModule } from '@angular/platform-server';
+
+        import { AppModule } from './app/app.module';
+        import { environment } from './environments/environment';
+
+        if (environment.production) {
+          enableProdMode();
+        }
+
+        renderModule(AppModule, {
+          document: '<app-root></app-root>',
+          url: '/'
+        });
+      `;
+
+      // tslint:disable:max-line-length
+      const output = stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { environment } from './environments/environment';
+
+        import * as __NgCli_bootstrap_1 from "./app/app.module.ngfactory";
+        import * as __NgCli_bootstrap_2 from "@angular/platform-server";
+
+        if (environment.production) {
+          enableProdMode();
+        }
+        __NgCli_bootstrap_2.renderModuleFactory(__NgCli_bootstrap_1.AppModuleNgFactory, {
+            document: '<app-root></app-root>',
+            url: '/'
+          });
+      `;
+      // tslint:enable:max-line-length
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const transformer = replaceServerBootstrap(
+        () => true,
+        () => ({ path: '/project/src/app/app.module', className: 'AppModule' }),
+        () => program.getTypeChecker(),
+      );
+      const result = transformTypescript(undefined, [transformer], program, compilerHost);
+
+      expect(oneLine`${result}`).toEqual(oneLine`${output}`);
+    });
+
+    it('should replace when the module is used in a config object', () => {
+      const input = stripIndent`
+        import * as express from 'express';
+
+        import { enableProdMode } from '@angular/core';
+        import { ngExpressEngine } from '@nguniversal/express-engine';
+
+        import { AppModule } from './app/app.module';
+        import { environment } from './environments/environment';
+
+        if (environment.production) {
+          enableProdMode();
+        }
+
+        const server = express();
+        server.engine('html', ngExpressEngine({
+          bootstrap: AppModule
+        }));
+      `;
+
+      // tslint:disable:max-line-length
+      const output = stripIndent`
+        import * as express from 'express';
+
+        import { enableProdMode } from '@angular/core';
+        import { ngExpressEngine } from '@nguniversal/express-engine';
+
+        import { environment } from './environments/environment';
+
+        import * as __NgCli_bootstrap_1 from "./app/app.module.ngfactory";
+
+        if (environment.production) {
+          enableProdMode();
+        }
+
+        const server = express();
+        server.engine('html', ngExpressEngine({
+          bootstrap: __NgCli_bootstrap_1.AppModuleNgFactory
+        }));
+      `;
+      // tslint:enable:max-line-length
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const transformer = replaceServerBootstrap(
+        () => true,
+        () => ({ path: '/project/src/app/app.module', className: 'AppModule' }),
+        () => program.getTypeChecker(),
+      );
+      const result = transformTypescript(undefined, [transformer], program, compilerHost);
+
+      expect(oneLine`${result}`).toEqual(oneLine`${output}`);
+    });
+
+    it('should replace bootstrap when barrel files are used', () => {
+      const input = stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { platformDynamicServer } from '@angular/platform-browser-dynamic';
+
+        import { AppModule } from './app';
+        import { environment } from './environments/environment';
+
+        if (environment.production) {
+          enableProdMode();
+        }
+
+        platformDynamicServer().bootstrapModule(AppModule);
+      `;
+
+      // tslint:disable:max-line-length
+      const output = stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { environment } from './environments/environment';
+
+        import * as __NgCli_bootstrap_1 from "./app/app.module.ngfactory";
+        import * as __NgCli_bootstrap_2 from "@angular/platform-server";
+
+        if (environment.production) {
+          enableProdMode();
+        }
+        __NgCli_bootstrap_2.platformServer().bootstrapModuleFactory(__NgCli_bootstrap_1.AppModuleNgFactory);
+      `;
+      // tslint:enable:max-line-length
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const transformer = replaceServerBootstrap(
+        () => true,
+        () => ({ path: '/project/src/app/app.module', className: 'AppModule' }),
+        () => program.getTypeChecker(),
+      );
+      const result = transformTypescript(undefined, [transformer], program, compilerHost);
+
+      expect(oneLine`${result}`).toEqual(oneLine`${output}`);
+    });
+
+    it('should not replace bootstrap when there is no entry module', () => {
+      const input = stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { platformDynamicServer } from '@angular/platform-browser-dynamic';
+
+        import { AppModule } from './app/app.module';
+        import { environment } from './environments/environment';
+
+        if (environment.production) {
+          enableProdMode();
+        }
+
+        platformDynamicServer().bootstrapModule(AppModule);
+      `;
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const transformer = replaceServerBootstrap(
+        () => true,
+        () => undefined,
+        () => program.getTypeChecker(),
+      );
+      const result = transformTypescript(undefined, [transformer], program, compilerHost);
+
+      expect(oneLine`${result}`).toEqual(oneLine`${input}`);
+    });
+  });
+});

--- a/packages/@ngtools/webpack/src/transformers/replace_server_bootstrap.ts
+++ b/packages/@ngtools/webpack/src/transformers/replace_server_bootstrap.ts
@@ -1,0 +1,135 @@
+// @ignoreDep typescript
+import * as ts from 'typescript';
+import { relative, dirname } from 'path';
+
+import { collectDeepNodes } from './ast_helpers';
+import { insertStarImport } from './insert_import';
+import { StandardTransform, ReplaceNodeOperation, TransformOperation } from './interfaces';
+import { makeTransform } from './make_transform';
+
+export function replaceServerBootstrap(
+  shouldTransform: (fileName: string) => boolean,
+  getEntryModule: () => { path: string, className: string },
+  getTypeChecker: () => ts.TypeChecker,
+): ts.TransformerFactory<ts.SourceFile> {
+
+  const standardTransform: StandardTransform = function (sourceFile: ts.SourceFile) {
+    const ops: TransformOperation[] = [];
+
+    const entryModule = getEntryModule();
+
+    if (!shouldTransform(sourceFile.fileName) || !entryModule) {
+      return ops;
+    }
+
+    // Find all identifiers.
+    const entryModuleIdentifiers = collectDeepNodes<ts.Identifier>(sourceFile,
+      ts.SyntaxKind.Identifier)
+      .filter(identifier => identifier.text === entryModule.className);
+
+    if (entryModuleIdentifiers.length === 0) {
+      return [];
+    }
+
+    const relativeEntryModulePath = relative(dirname(sourceFile.fileName), entryModule.path);
+    const normalizedEntryModulePath = `./${relativeEntryModulePath}`.replace(/\\/g, '/');
+    const factoryClassName = entryModule.className + 'NgFactory';
+    const factoryModulePath = normalizedEntryModulePath + '.ngfactory';
+
+    // Find the bootstrap calls.
+    entryModuleIdentifiers.forEach(entryModuleIdentifier => {
+      if (!entryModuleIdentifier.parent) {
+        return;
+      }
+
+      if (entryModuleIdentifier.parent.kind !== ts.SyntaxKind.CallExpression &&
+        entryModuleIdentifier.parent.kind !== ts.SyntaxKind.PropertyAssignment) {
+        return;
+      }
+
+      if (entryModuleIdentifier.parent.kind === ts.SyntaxKind.CallExpression) {
+        // Figure out if it's a `platformDynamicServer().bootstrapModule(AppModule)` call.
+
+        const callExpr = entryModuleIdentifier.parent as ts.CallExpression;
+
+        if (callExpr.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
+
+          const propAccessExpr = callExpr.expression as ts.PropertyAccessExpression;
+
+          if (!(propAccessExpr.name.text === 'bootstrapModule'
+            && propAccessExpr.expression.kind === ts.SyntaxKind.CallExpression)) {
+            return;
+          }
+
+          const bootstrapModuleIdentifier = propAccessExpr.name;
+          const innerCallExpr = propAccessExpr.expression as ts.CallExpression;
+
+          if (!(
+            innerCallExpr.expression.kind === ts.SyntaxKind.Identifier
+            && (innerCallExpr.expression as ts.Identifier).text === 'platformDynamicServer'
+          )) {
+            return;
+          }
+
+          const platformDynamicServerIdentifier = innerCallExpr.expression as ts.Identifier;
+
+          const idPlatformServer = ts.createUniqueName('__NgCli_bootstrap_');
+          const idNgFactory = ts.createUniqueName('__NgCli_bootstrap_');
+
+          // Add the transform operations.
+          ops.push(
+            // Replace the entry module import.
+            ...insertStarImport(sourceFile, idNgFactory, factoryModulePath),
+            new ReplaceNodeOperation(sourceFile, entryModuleIdentifier,
+              ts.createPropertyAccess(idNgFactory, ts.createIdentifier(factoryClassName))),
+            // Replace the platformBrowserDynamic import.
+            ...insertStarImport(sourceFile, idPlatformServer, '@angular/platform-server'),
+            new ReplaceNodeOperation(sourceFile, platformDynamicServerIdentifier,
+              ts.createPropertyAccess(idPlatformServer, 'platformServer')),
+            new ReplaceNodeOperation(sourceFile, bootstrapModuleIdentifier,
+              ts.createIdentifier('bootstrapModuleFactory')),
+          );
+        } else if (callExpr.expression.kind === ts.SyntaxKind.Identifier) {
+          // Figure out if it is renderModule
+
+          const identifierExpr = callExpr.expression as ts.Identifier;
+
+          if (identifierExpr.text !== 'renderModule') {
+            return;
+          }
+
+          const renderModuleIdentifier = identifierExpr as ts.Identifier;
+
+          const idPlatformServer = ts.createUniqueName('__NgCli_bootstrap_');
+          const idNgFactory = ts.createUniqueName('__NgCli_bootstrap_');
+
+          ops.push(
+            // Replace the entry module import.
+            ...insertStarImport(sourceFile, idNgFactory, factoryModulePath),
+            new ReplaceNodeOperation(sourceFile, entryModuleIdentifier,
+              ts.createPropertyAccess(idNgFactory, ts.createIdentifier(factoryClassName))),
+            // Replace the renderModule import.
+            ...insertStarImport(sourceFile, idPlatformServer, '@angular/platform-server'),
+            new ReplaceNodeOperation(sourceFile, renderModuleIdentifier,
+              ts.createPropertyAccess(idPlatformServer, 'renderModuleFactory')),
+          );
+        }
+      } else if (entryModuleIdentifier.parent.kind === ts.SyntaxKind.PropertyAssignment) {
+        // This is for things that accept a module as a property in a config object
+        // .ie the express engine
+
+        const idNgFactory = ts.createUniqueName('__NgCli_bootstrap_');
+
+        ops.push(
+          ...insertStarImport(sourceFile, idNgFactory, factoryModulePath),
+          new ReplaceNodeOperation(sourceFile, entryModuleIdentifier,
+            ts.createPropertyAccess(idNgFactory, ts.createIdentifier(factoryClassName)))
+        );
+      }
+    });
+
+    return ops;
+  };
+
+  return makeTransform(standardTransform, getTypeChecker);
+}

--- a/packages/@ngtools/webpack/src/type_checker_bootstrap.js
+++ b/packages/@ngtools/webpack/src/type_checker_bootstrap.js
@@ -1,2 +1,2 @@
 require('../../../../lib/bootstrap-local');
-require('./type_checker.ts');
+require('./type_checker_worker.ts');

--- a/packages/@ngtools/webpack/src/type_checker_worker.ts
+++ b/packages/@ngtools/webpack/src/type_checker_worker.ts
@@ -1,0 +1,53 @@
+import * as process from 'process';
+
+import { time, timeEnd } from './benchmark';
+import { CancellationToken } from './gather_diagnostics';
+
+import {
+  AUTO_START_ARG,
+  TypeCheckerMessage,
+  InitMessage,
+  MESSAGE_KIND,
+  UpdateMessage,
+  TypeChecker
+} from './type_checker';
+
+let typeChecker: TypeChecker;
+let lastCancellationToken: CancellationToken;
+
+// only listen to messages if started from the AngularCompilerPlugin
+if (process.argv.indexOf(AUTO_START_ARG) >= 0) {
+  process.on('message', (message: TypeCheckerMessage) => {
+    time('TypeChecker.message');
+    switch (message.kind) {
+      case MESSAGE_KIND.Init:
+        const initMessage = message as InitMessage;
+        typeChecker = new TypeChecker(
+          initMessage.compilerOptions,
+          initMessage.basePath,
+          initMessage.jitMode,
+          initMessage.rootNames,
+        );
+        break;
+      case MESSAGE_KIND.Update:
+        if (!typeChecker) {
+          throw new Error('TypeChecker: update message received before initialization');
+        }
+        if (lastCancellationToken) {
+          // This cancellation token doesn't seem to do much, messages don't seem to be processed
+          // before the diagnostics finish.
+          lastCancellationToken.requestCancellation();
+        }
+        const updateMessage = message as UpdateMessage;
+        lastCancellationToken = new CancellationToken();
+        typeChecker.update(updateMessage.rootNames, updateMessage.changedCompilationFiles,
+          lastCancellationToken);
+        break;
+      default:
+        throw new Error(`TypeChecker: Unexpected message received: ${message}.`);
+    }
+    timeEnd('TypeChecker.message');
+  });
+}
+
+

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/app.component.html
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/app.component.html
@@ -1,0 +1,5 @@
+<div>
+  <h1>hello world</h1>
+  <a [routerLink]="['lazy']">lazy</a>
+  <router-outlet></router-outlet>
+</div>

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/app.component.scss
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/app.component.scss
@@ -1,0 +1,3 @@
+:host {
+  background-color: blue;
+}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/app.component.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/app.component.ts
@@ -1,0 +1,15 @@
+import {Component, ViewEncapsulation} from '@angular/core';
+import {MyInjectable} from './injectable';
+
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class AppComponent {
+  constructor(public inj: MyInjectable) {
+    console.log(inj);
+  }
+}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/app.module.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/app.module.ts
@@ -1,0 +1,36 @@
+import { NgModule, Component } from '@angular/core';
+import { ServerModule  } from '@angular/platform-server';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+
+import { AppComponent } from './app.component';
+import { MyInjectable } from './injectable';
+
+@Component({
+  selector: 'home-view',
+  template: 'home!'
+})
+export class HomeView {}
+
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    HomeView
+  ],
+  imports: [
+    BrowserModule.withServerTransition({
+      appId: 'app'
+    }),
+    ServerModule,
+    RouterModule.forRoot([
+      {path: 'lazy', loadChildren: './lazy.module#LazyModule'},
+      {path: '', component: HomeView}
+    ])
+  ],
+  providers: [MyInjectable],
+  bootstrap: [AppComponent]
+})
+export class AppModule {
+  static testProp: string;
+}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/feature/feature.module.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/feature/feature.module.ts
@@ -1,0 +1,20 @@
+import {NgModule, Component} from '@angular/core';
+import {RouterModule} from '@angular/router';
+
+@Component({
+  selector: 'feature-component',
+  template: 'foo.html'
+})
+export class FeatureComponent {}
+
+@NgModule({
+  declarations: [
+    FeatureComponent
+  ],
+  imports: [
+    RouterModule.forChild([
+      { path: '', component: FeatureComponent}
+    ])
+  ]
+})
+export class FeatureModule {}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/feature/lazy-feature.module.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/feature/lazy-feature.module.ts
@@ -1,0 +1,23 @@
+import {NgModule, Component} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {HttpModule, Http} from '@angular/http';
+
+@Component({
+  selector: 'lazy-feature-comp',
+  template: 'lazy feature!'
+})
+export class LazyFeatureComponent {}
+
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+      {path: '', component: LazyFeatureComponent, pathMatch: 'full'},
+      {path: 'feature', loadChildren: './feature.module#FeatureModule'}
+    ]),
+    HttpModule
+  ],
+  declarations: [LazyFeatureComponent]
+})
+export class LazyFeatureModule {
+  constructor(http: Http) {}
+}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/injectable.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/injectable.ts
@@ -1,0 +1,8 @@
+import {Injectable, Inject, ViewContainerRef} from '@angular/core';
+import {DOCUMENT} from '@angular/platform-browser';
+
+
+@Injectable()
+export class MyInjectable {
+  constructor(@Inject(DOCUMENT) public doc) {}
+}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/lazy.module.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/lazy.module.ts
@@ -1,0 +1,26 @@
+import {NgModule, Component} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {HttpModule, Http} from '@angular/http';
+
+@Component({
+  selector: 'lazy-comp',
+  template: 'lazy!'
+})
+export class LazyComponent {}
+
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+     {path: '', component: LazyComponent, pathMatch: 'full'},
+     {path: 'feature', loadChildren: './feature/feature.module#FeatureModule'},
+     {path: 'lazy-feature', loadChildren: './feature/lazy-feature.module#LazyFeatureModule'}
+    ]),
+    HttpModule
+  ],
+  declarations: [LazyComponent]
+})
+export class LazyModule {
+  constructor(http: Http) {}
+}
+
+export class SecondModule {}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/main.commonjs.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/main.commonjs.ts
@@ -1,0 +1,1 @@
+export { AppModule } from './app.module';

--- a/tests/e2e/assets/webpack/test-server-app-ng5/app/main.ts
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/app/main.ts
@@ -1,0 +1,12 @@
+import 'core-js/es7/reflect';
+import {platformDynamicServer, renderModule} from '@angular/platform-server';
+import {AppModule} from './app.module';
+
+AppModule.testProp = 'testing';
+
+platformDynamicServer().bootstrapModule(AppModule);
+
+renderModule(AppModule, {
+  document: '<app-root></app-root>',
+  url: '/'
+});

--- a/tests/e2e/assets/webpack/test-server-app-ng5/index.html
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+  <base href="">
+</head>
+<body>
+  <app-root></app-root>
+  <script src="node_modules/zone.js/dist/zone.js"></script>
+  <script src="dist/app.main.js"></script>
+</body>
+</html>

--- a/tests/e2e/assets/webpack/test-server-app-ng5/index.js
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/index.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const { AppModuleNgFactory } = require('./dist/app.main');
+const { renderModuleFactory } = require('@angular/platform-server');
+
+require('zone.js/dist/zone-node');
+
+renderModuleFactory(AppModuleNgFactory, {
+  url: '/',
+  document: '<app-root></app-root>'
+}).then(html => {
+  fs.writeFileSync('dist/index.html', html);
+})

--- a/tests/e2e/assets/webpack/test-server-app-ng5/package.json
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "test",
+  "license": "MIT",
+  "dependencies": {
+    "@angular/animations": "^5.0.0",
+    "@angular/common": "^5.0.0",
+    "@angular/compiler": "^5.0.0",
+    "@angular/compiler-cli": "^5.0.0",
+    "@angular/core": "^5.0.0",
+    "@angular/http": "^5.0.0",
+    "@angular/platform-browser": "^5.0.0",
+    "@angular/platform-browser-dynamic": "^5.0.0",
+    "@angular/platform-server": "^5.0.0",
+    "@angular/router": "^5.0.0",
+    "@ngtools/webpack": "0.0.0",
+    "core-js": "^2.4.1",
+    "rxjs": "^5.4.2",
+    "zone.js": "^0.8.14"
+  },
+  "devDependencies": {
+    "node-sass": "^4.5.0",
+    "performance-now": "^0.2.0",
+    "raw-loader": "^0.5.1",
+    "sass-loader": "^6.0.3",
+    "typescript": "~2.5.0",
+    "webpack": "2.2.1"
+  }
+}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/tsconfig.json
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "baseUrl": "",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "target": "es5",
+    "noImplicitAny": false,
+    "sourceMap": true,
+    "mapRoot": "",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [
+      "es2017",
+      "dom"
+    ],
+    "outDir": "lib",
+    "skipLibCheck": true,
+    "rootDir": "."
+  },
+  "angularCompilerOptions": {
+    "genDir": "./app/ngfactory",
+    "entryModule": "app/app.module#AppModule"
+  }
+}

--- a/tests/e2e/assets/webpack/test-server-app-ng5/webpack.config.js
+++ b/tests/e2e/assets/webpack/test-server-app-ng5/webpack.config.js
@@ -1,0 +1,32 @@
+const { AngularCompilerPlugin, PLATFORM } = require('@ngtools/webpack');
+
+module.exports = {
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  target: 'web',
+  entry: './app/main.ts',
+  output: {
+    path: './dist',
+    publicPath: 'dist/',
+    filename: 'app.main.js'
+  },
+  plugins: [
+    new AngularCompilerPlugin({
+      tsConfigPath: './tsconfig.json',
+      mainPath: './app/main.ts',
+      platform: PLATFORM.Server
+    })
+  ],
+  module: {
+    loaders: [
+      { test: /\.scss$/, loaders: ['raw-loader', 'sass-loader'] },
+      { test: /\.css$/, loader: 'raw-loader' },
+      { test: /\.html$/, loader: 'raw-loader' },
+      { test: /\.ts$/, loader: '@ngtools/webpack' }
+    ]
+  },
+  devServer: {
+    historyApiFallback: true
+  }
+};

--- a/tests/e2e/tests/basic/rebuild.ts
+++ b/tests/e2e/tests/basic/rebuild.ts
@@ -20,14 +20,9 @@ export default function() {
     return Promise.resolve();
   }
 
-  let oldNumberOfChunks = 0;
-  const chunkRegExp = /chunk\s+\{/g;
+  const lazyChunkRegExp = /lazy\.module\.chunk\.js/g;
 
   return execAndWaitForOutputToMatch('ng', ['serve'], validBundleRegEx)
-    // Count the bundles.
-    .then(({ stdout }) => {
-      oldNumberOfChunks = stdout.split(chunkRegExp).length;
-    })
     // Add a lazy module.
     .then(() => ng('generate', 'module', 'lazy', '--routing'))
     // Should trigger a rebuild with a new bundle.
@@ -65,8 +60,7 @@ export default function() {
     // Count the bundles.
     .then((results) => {
       const stdout = results[0].stdout;
-      let newNumberOfChunks = stdout.split(chunkRegExp).length;
-      if (oldNumberOfChunks >= newNumberOfChunks) {
+      if (!lazyChunkRegExp.test(stdout)) {
         throw new Error('Expected webpack to create a new chunk, but did not.');
       }
     })

--- a/tests/e2e/tests/packages/webpack/server-ng5.ts
+++ b/tests/e2e/tests/packages/webpack/server-ng5.ts
@@ -1,0 +1,23 @@
+import { normalize } from 'path';
+import { createProjectFromAsset } from '../../../utils/assets';
+import { exec } from '../../../utils/process';
+import { expectFileToMatch, rimraf } from '../../../utils/fs';
+
+
+export default function (skipCleaning: () => void) {
+  return Promise.resolve()
+    .then(() => createProjectFromAsset('webpack/test-server-app'))
+    .then(() => exec(normalize('node_modules/.bin/webpack')))
+    .then(() => expectFileToMatch('dist/app.main.js',
+      new RegExp('MyInjectable.ctorParameters = .*'
+      + 'type: undefined, decorators.*Inject.*args: .*DOCUMENT.*'))
+    .then(() => expectFileToMatch('dist/app.main.js',
+      new RegExp('AppComponent.ctorParameters = .*MyInjectable'))
+    .then(() => expectFileToMatch('dist/app.main.js',
+      /AppModule \*\/\].*\.testProp = \'testing\'/))
+    .then(() => expectFileToMatch('dist/app.main.js',
+      /platformServer \*\/\]\)\(\)\.bootstrapModuleFactory\(.*\/\* AppModuleNgFactory \*\/\]/))
+    .then(() => expectFileToMatch('dist/app.main.js',
+      /renderModuleFactory \*\/\].*\/\* AppModuleNgFactory \*\/\]/))
+    .then(() => skipCleaning());
+}


### PR DESCRIPTION
Move the listening to messages from the type_checker.ts to a seperate
type_checker_worker.ts file. Only start listening to messages when a
magic 'auto start' argument is present in in the argument list,
preventing undesired eaves dropping on other processes.

Also rename type_checker.ts -> type_checker_messages.ts, as it now
contains only the messages.