### PR TITLE
expose preflight join as phases

### DIFF
--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -140,7 +140,11 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
 
   private isPackageInstalled(name: string): boolean {
     try {
-      resolve(name, { checkLocal: true, basedir: this.workspace.root });
+      resolve(name, {
+        checkLocal: true,
+        basedir: this.workspace.root,
+        resolvePackageJson: true,
+      });
 
       return true;
     } catch (e) {


### PR DESCRIPTION
ng-add checks if a specified collection is installed, and if not it'd
proceed to install the package. However, `isPackageInstalled` would, by
default, resolve the main field or the index of the package. Not all NPM
packages specify the main field or provide an index file. It should
be sufficient to just check the presence of `package.json` to detect
whether a package is installed or not.

For example, `ng add @angular/bazel` should not install the package if
it's already installed locally. `@angular/bazel` does not specify a main
field not an index file in its `package.json`.